### PR TITLE
Added MacOS installation instructions.

### DIFF
--- a/implementations/OpenSesame/README.md
+++ b/implementations/OpenSesame/README.md
@@ -26,7 +26,7 @@ You should now see `(opensesame)` prepended to the prompt of your terminal.
 2. Install OpenSesame and all its dependencies using:
 
 ```
-conda install python-opensesame psychopy pysoundfile -c cogsci -c conda-forge
+conda install python-opensesame psychopy python-sounddevice -c cogsci -c conda-forge
 pip install expyriment
 ```
 

--- a/implementations/OpenSesame/README.md
+++ b/implementations/OpenSesame/README.md
@@ -10,10 +10,27 @@ Double-click on `opensesame.bat` to start OpenSesame
 
 ## Mac OS
 
+The easiest way is to install and use the most current version of OpenSesame on MacOS is to use the Anaconda/Miniconda distribution. M Make sure you have Anaconda or Miniconda installed and have access to the `conda` command. Then follow these steps:
+
+1. (Optional) Create a new virtual environment to install OpenSesame in:
+
 ```
-Anaconda installation instructions here
+conda create -n opensesame python=3.7 python
+```
+And activate this virtual environment with:
+```
+conda activate opensesame
+```
+You should now see `(opensesame)` prepended to the prompt of your terminal.
+
+2. Install OpenSesame and all its dependencies using:
+
+```
+conda install python-opensesame psychopy pysoundfile -c cogsci -c conda-forge
+pip install expyriment
 ```
 
+3. Start OpenSesame by executing the command `opensesame` in the terminal.
 
 ## Ubuntu
 


### PR DESCRIPTION
I'm already opening a PR for the installation instructions for MacOS. I am not finished and haven't tested the commands yet (I'm currently not working on my Mac), and I still have to do this later.

I do have some questions before I continue:

- I see this is for the collaborative timing test. Do you use specific versions of the packages and their dependencies for this? Shouldn't the package versions be the same on all platforms, or do you just use the latest ones?
- Considering it is for the timing test, there is no need to add plugins/extensions such as pygaze, osf, etc?
- Do you want to install the latest version of pygame using pip? Or just use the (ancient) version of pygame that is available from the cogsci channel?
- Should I also add instructions to just install and run Opensesame from its app version?